### PR TITLE
[API]: list, report 페이지 delete/patch 연결 완료

### DIFF
--- a/AESPArd_FE/Controller/HomeViewController.swift
+++ b/AESPArd_FE/Controller/HomeViewController.swift
@@ -104,6 +104,13 @@ class HomeViewController: UIViewController {
         
         //my에서 서비스 초기화
         NotificationCenter.default.addObserver(self, selector: #selector(reloadDataBasedOnFilterMode), name: .didResetService, object: nil)
+        
+        //list에서 delete/patch 반영
+        NotificationCenter.default.addObserver(self, selector: #selector(renderingHome), name: .listbackHomeNotification, object: nil)
+        
+        //report에서 delete/patch 반영
+        NotificationCenter.default.addObserver(self, selector: #selector(renderingHome), name: .reportbackHomeNotification, object: nil)
+        
     }
     
     deinit {
@@ -120,6 +127,11 @@ class HomeViewController: UIViewController {
         NotificationCenter.default.removeObserver(self, name: .updateFavoriteNotification, object: nil)
         
         NotificationCenter.default.removeObserver(self, name: .didResetService, object: nil)
+        
+        NotificationCenter.default.removeObserver(self, name: .listbackHomeNotification, object: nil)
+        
+        NotificationCenter.default.removeObserver(self, name: .reportbackHomeNotification, object: nil)
+    
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -127,7 +139,6 @@ class HomeViewController: UIViewController {
         
         getRecordsAverageAPI()
         reloadDataBasedOnFilterMode()
-        tableView.reloadData()
     }
     
     //MARK: -  API
@@ -242,6 +253,8 @@ class HomeViewController: UIViewController {
         
     }
     
+    //MARK: - 관련 메서드(api 함수 하나 끼어있음)
+    
     // 삭제 버튼 상태를 토글하는 메서드
     @objc func handleButtonToggleNotification() {
         isDeleteMode.toggle()
@@ -303,6 +316,11 @@ class HomeViewController: UIViewController {
         self.definesPresentationContext = true // 현재 컨텍스트를 정의
         
         self.present(modalViewController, animated: true)
+    }
+    
+    @objc func renderingHome(){
+        getRecordsAverageAPI()
+        reloadDataBasedOnFilterMode()
     }
     
 }
@@ -421,6 +439,10 @@ extension HomeViewController: UITabBarControllerDelegate {
             
             // 모든 모달 창 닫기
             dismissModalsRecursively(from: homeVC, isLastModal: true)
+            
+            //API
+            getRecordsAverageAPI()
+            reloadDataBasedOnFilterMode()
         }
         
         return true

--- a/AESPArd_FE/Controller/HomeViewController.swift
+++ b/AESPArd_FE/Controller/HomeViewController.swift
@@ -57,7 +57,7 @@ class HomeViewController: UIViewController {
         UIApplication.shared.isIdleTimerDisabled = false
         
         // 홈뷰에서 아래 함수들 없어도 되는지 확인하고 삭제할 것
-//        getUserNameAPI()
+        getUserNameAPI()
 //        getRecordsAverageAPI()
 //        fetchPresentationList()
         
@@ -125,9 +125,9 @@ class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        getUserNameAPI()
         getRecordsAverageAPI()
         reloadDataBasedOnFilterMode()
+        tableView.reloadData()
     }
     
     //MARK: -  API

--- a/AESPArd_FE/Controller/ListViewController.swift
+++ b/AESPArd_FE/Controller/ListViewController.swift
@@ -280,6 +280,7 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
             //삭제 모드가 아니면 selectedDeleteId 배열 초기화
             if(selectedDeleteId.count>0){
                 deleteSelectedPracticeAPI()
+                renderingList()
             }
             selectedDeleteId.removeAll()
         }

--- a/AESPArd_FE/Controller/ListViewController.swift
+++ b/AESPArd_FE/Controller/ListViewController.swift
@@ -16,6 +16,8 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
     var presentationData: PresentationList
     var practiceList : [GetPractice] = []
     
+    var editNmae: String = ""
+    
     // 초기화 메서드 정의
     init(presentationData: PresentationList) {
         self.presentationData = presentationData
@@ -200,6 +202,39 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
             }
         }
     }
+    
+    @objc func deleteOnePresentationAPI() {
+        networkManager.deleteOnePresentation(presentationId: presentationData.presentationId) { [weak self] result in
+            switch result {
+            case .success(let scores):
+                print("히힛 삭제 성공")
+            case .failure(let error):
+                print("Error fetching scores: \(error)")
+            }
+        }
+    }
+    
+    @objc func patchPresentationNameAPI() {
+        networkManager.patchPresentationName(presentationId: presentationData.presentationId , name: editNmae){ [weak self] result in
+            switch result {
+            case .success(let scores):
+                print("히힛 이름 수정 성공")
+            case .failure(let error):
+                print("Error fetching scores: \(error)")
+            }
+        }
+    }
+    
+    @objc func deleteSelectedPracticeAPI() {
+        networkManager.deleteSelectedPractice(practiceIds: selectedDeleteId){ [weak self] result in
+            switch result {
+            case .success(let scores):
+                print("연습 선택 삭제 성공")
+            case .failure(let error):
+                print("Error fetching scores: \(error)")
+            }
+        }
+    }
 
     
     
@@ -235,6 +270,9 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
         
         if !isDeleteMode {
             //삭제 모드가 아니면 selectedDeleteId 배열 초기화
+            if(selectedDeleteId.count>0){
+                deleteSelectedPracticeAPI()
+            }
             selectedDeleteId.removeAll()
         }
         
@@ -274,6 +312,9 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
             // 텍스트 필드에서 입력된 이름을 가져옴
             if let newName = alertController.textFields?.first?.text, !newName.isEmpty {
                 self.header.headerLabel.text = newName
+                self.editNmae = newName
+                
+                self.patchPresentationNameAPI()
             }
         }
         
@@ -298,6 +339,8 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
         // 삭제 버튼 추가
         let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in
             print("삭제됨")
+            self.deleteOnePresentationAPI()
+            self.dismissViewController() //화면 벗어나기
         }
         
         alertController.addAction(cancelAction)
@@ -364,6 +407,12 @@ extension ListViewController: UITableViewDelegate, UITableViewDataSource {
             cell.backgroundColor = .clear
             cell.selectionStyle = .none
             
+            if(selectedDeleteId.count == 0){
+                cell.deleteButton.setTitle("삭제하기", for: .normal)
+            }
+            else{
+                cell.deleteButton.setTitle("\(selectedDeleteId.count)개 삭제하기", for: .normal)
+            }
             cell.configure(practiceCount: practiceList.count)
         
             return cell

--- a/AESPArd_FE/Controller/ListViewController.swift
+++ b/AESPArd_FE/Controller/ListViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+extension Notification.Name {
+    static let listbackHomeNotification = Notification.Name("listbackHomeNotification")
+}
+
 class ListViewController : UIViewController, ListHeaderTableCellDelegate {
     
     // 클백 연결을 위한 NesworkManager 연결
@@ -124,6 +128,9 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
         
         //삭제할꺼 리스트 추가 감지
         NotificationCenter.default.addObserver(self, selector: #selector(handleDeleteSelection(_:)), name: .selectedDeletePracticeNotification, object: nil)
+        
+        //report에서 delete/patch 반영
+        NotificationCenter.default.addObserver(self, selector: #selector(renderingList), name: .reportbackHomeNotification, object: nil)
     }
     
     deinit {
@@ -243,6 +250,7 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
     // ListHeaderTableCellDelegate 메소드 - 뒤로가기 버튼
     func dismissViewController() {
         self.dismiss(animated: true, completion: nil)
+        NotificationCenter.default.post(name:.listbackHomeNotification, object: nil)
     }
     
     //edit 버튼 클릭시 UIview 등장/숨기기 토글
@@ -290,6 +298,11 @@ class ListViewController : UIViewController, ListHeaderTableCellDelegate {
         }
         tableView.reloadData()
 
+    }
+    
+    @objc func renderingList(){
+        getRecentScores()
+        getPracticeData()
     }
  
     //MARK: -Alert 함수

--- a/AESPArd_FE/Controller/ResultReportViewController.swift
+++ b/AESPArd_FE/Controller/ResultReportViewController.swift
@@ -21,6 +21,9 @@ class ResultReportViewController: UIViewController,PracticeHeaderTableCellDelega
     var isFromHome: Bool = true
     private var analysisId: String?
     
+    //이름 변경
+    var editName: String = ""
+    
     //비디오 플레이어
     private var player: AVPlayer?
    
@@ -203,6 +206,29 @@ class ResultReportViewController: UIViewController,PracticeHeaderTableCellDelega
             }
         }
     }
+    
+    @objc func deleteOnePracticeAPI() {
+        networkManager.deleteOnePractice(practiceId: practiceData.id){ [weak self] result in
+            switch result {
+            case .success(let scores):
+                print("연습 삭제 성공")
+            case .failure(let error):
+                print("Error fetching scores: \(error)")
+            }
+        }
+    }
+    
+    @objc func patchPracticeNameAPI() {
+        networkManager.patchPracticeName(practiceId: practiceData.id, name: editName){ [weak self] result in
+            switch result {
+            case .success(let scores):
+                print("연습 이름 수정 성공")
+            case .failure(let error):
+                print("Error fetching scores: \(error)")
+            }
+        }
+    }
+    
 
     
     
@@ -375,6 +401,8 @@ class ResultReportViewController: UIViewController,PracticeHeaderTableCellDelega
             // 텍스트 필드에서 입력된 이름을 가져옴
             if let newName = alertController.textFields?.first?.text, !newName.isEmpty {
                 self.practiceHeaderView.headerLabel.text = newName
+                self.editName = newName
+                self.patchPracticeNameAPI()
             }
         }
         
@@ -399,6 +427,8 @@ class ResultReportViewController: UIViewController,PracticeHeaderTableCellDelega
         // 삭제 버튼 추가
         let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in
             print("삭제됨")
+            self.deleteOnePracticeAPI()
+            self.dismiss(animated: true, completion: nil)
         }
         
         alertController.addAction(cancelAction)

--- a/AESPArd_FE/Controller/ResultReportViewController.swift
+++ b/AESPArd_FE/Controller/ResultReportViewController.swift
@@ -9,6 +9,10 @@ import UIKit
 import Photos
 import AVKit
 
+extension Notification.Name {
+    static let reportbackHomeNotification = Notification.Name("reportbackHomeNotification")
+}
+
 class ResultReportViewController: UIViewController,PracticeHeaderTableCellDelegate {
     
     // 클백 연결을 위한 NesworkManager 연결
@@ -292,6 +296,8 @@ class ResultReportViewController: UIViewController,PracticeHeaderTableCellDelega
         } else {
             self.presentingViewController?.presentingViewController?.presentingViewController?.presentingViewController?.dismiss(animated: true)
         }
+        
+        NotificationCenter.default.post(name:.reportbackHomeNotification, object: nil)
         
     }
     

--- a/AESPArd_FE/Network/API/PracticeService.swift
+++ b/AESPArd_FE/Network/API/PracticeService.swift
@@ -7,6 +7,10 @@ enum PracticeService {
     case getPractice(presentationId: String)
     case getRecentScores(presentationId: String)
     case getSinglePracticeInLoadingScreen(presentationId: String)
+    
+    case deleteOnePracticeByPracticeId(practiceId: String)
+    case deleteSelectedPractice(practiceIds: [String])
+    case patchPracticeNameByPracticeId(practiceId: String, name: String)
 }
 
 extension PracticeService: TargetType {
@@ -22,6 +26,13 @@ extension PracticeService: TargetType {
             return "/practices/recent-scores"
         case .getSinglePracticeInLoadingScreen:
             return "/practices/recent"
+
+        case .deleteOnePracticeByPracticeId(let practiceId):
+            return "/practices/\(practiceId)/one-delete"
+        case .deleteSelectedPractice :
+            return "/practices/batch-delete"
+        case .patchPracticeNameByPracticeId(let practiceId, _):
+            return "/practices/\(practiceId)/update-name"
         }
     }
     
@@ -33,6 +44,12 @@ extension PracticeService: TargetType {
             return .get
         case .getSinglePracticeInLoadingScreen:
             return .get
+        case .deleteOnePracticeByPracticeId :
+            return .delete
+        case .deleteSelectedPractice :
+            return .delete
+        case .patchPracticeNameByPracticeId:
+            return .patch
         }
     }
     
@@ -52,6 +69,15 @@ extension PracticeService: TargetType {
             return .requestParameters(
                 parameters: ["presentationId": presentationId],
                 encoding: URLEncoding.default)
+            
+        case .deleteOnePracticeByPracticeId(let practiceId):
+            return .requestPlain
+            
+        case .deleteSelectedPractice(let practiceIds):
+            return .requestCustomJSONEncodable(practiceIds, encoder: JSONEncoder())
+        
+        case .patchPracticeNameByPracticeId(let practiceId, let name):
+            return .requestCustomJSONEncodable(name, encoder: JSONEncoder())
         }
     }
     

--- a/AESPArd_FE/Network/API/PresentationsService.swift
+++ b/AESPArd_FE/Network/API/PresentationsService.swift
@@ -15,6 +15,9 @@ enum PresentationsService {
     case getAllPresentations(userId: String)
     case deleteAllDeletePresentation(userId: String)
     case searchPresentations(userId: String, searchTerm: String)
+    
+    case deleteOnePresentation(presentationId: String)
+    case pathPresentationNameByPresentaion(presentationId: String, name: String)
 }
 
 extension PresentationsService: TargetType {
@@ -38,7 +41,11 @@ extension PresentationsService: TargetType {
             return "/presentations/\(userId)/all-delete"
         case .searchPresentations(let userId, _):
             return "/presentations/search/\(userId)"
-            
+        
+        case .deleteOnePresentation(let presentationId):
+            return "/presentations/\(presentationId)/one-delete"
+        case .pathPresentationNameByPresentaion(let presentationId, _):
+            return "/presentations/\(presentationId)/update-name"
         }
     }
     
@@ -58,6 +65,10 @@ extension PresentationsService: TargetType {
             return .delete
         case .searchPresentations:
             return .get
+        case .deleteOnePresentation:
+            return .delete
+        case .pathPresentationNameByPresentaion :
+            return .patch
         }
     }
     
@@ -82,6 +93,12 @@ extension PresentationsService: TargetType {
             
         case .searchPresentations(_, let searchTerm):
             return .requestParameters(parameters: ["searchTerm": searchTerm], encoding: URLEncoding.default)
+            
+        case .deleteOnePresentation(let presentationId):
+            return .requestPlain
+            
+        case .pathPresentationNameByPresentaion(let presentationId, let name):
+            return .requestCustomJSONEncodable(name, encoder: JSONEncoder())
         }
         
     }

--- a/AESPArd_FE/Network/Provider/NetworkManager.swift
+++ b/AESPArd_FE/Network/Provider/NetworkManager.swift
@@ -470,6 +470,66 @@ final class NetworkManager {
             }
         }
     }
-
+    
+    //MARK: - 발표 이름 수정
+    func patchPresentationName(presentationId: String, name: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        presentationServiceProvider.request(.pathPresentationNameByPresentaion(presentationId: presentationId, name: name)){ result in
+            switch result {
+            case .success(_):
+                    completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    //MARK: - 발표 하나 삭제
+    func deleteOnePresentation(presentationId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        presentationServiceProvider.request(.deleteOnePresentation(presentationId: presentationId)){ result in
+            switch result {
+            case .success(_):
+                    completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    //MARK: - 연습 하나 삭제
+    func deleteOnePractice(practiceId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        practiceServiceProvider.request(.deleteOnePracticeByPracticeId(practiceId: practiceId)){ result in
+            switch result {
+            case .success(_):
+                    completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    //MARK: - 연습 선택 삭제
+    func deleteSelectedPractice(practiceIds: [String], completion: @escaping (Result<Void, Error>) -> Void) {
+        practiceServiceProvider.request(.deleteSelectedPractice(practiceIds: practiceIds)){ result in
+            switch result {
+            case .success(_):
+                    completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    //MARK: - 연습 이름 수정
+    func patchPracticeName(practiceId: String, name: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        practiceServiceProvider.request(.patchPracticeNameByPracticeId(practiceId: practiceId, name: name)){ result in
+            switch result {
+            case .success(_):
+                    completion(.success(()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+    
 }
 

--- a/AESPArd_FE/View/ListTableView/DeleteSelectedListTableCell.swift
+++ b/AESPArd_FE/View/ListTableView/DeleteSelectedListTableCell.swift
@@ -35,7 +35,7 @@ class DeleteSelectedListTableCell: UITableViewCell {
     let deleteButton: UIButton = {
         let button = UIButton(type: .custom)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("삭제하기", for: .normal)
+//        button.setTitle("삭제하기", for: .normal)
         button.setTitleColor(UIColor(red: 0.616, green: 0.624, blue: 0.647, alpha: 1), for: .normal)
         button.titleLabel?.font = UIFont(name: "Pretendard-Medium", size: 14)
         button.setImage(UIImage(named: "trash"), for: .normal)

--- a/AESPArd_FE/View/ListTableView/LineChartCustomView.swift
+++ b/AESPArd_FE/View/ListTableView/LineChartCustomView.swift
@@ -65,7 +65,7 @@ class LineChartCustomView: UIView {
         self.myLineChart.xAxis.avoidFirstLastClippingEnabled = true
         
         // X축 라벨 색상 및 폰트 설정
-        self.myLineChart.xAxis.labelTextColor = UIColor(red: 0.427, green: 0.439, blue: 0.471, alpha: 1)
+        self.myLineChart.xAxis.labelTextColor = .white
         self.myLineChart.xAxis.labelFont = UIFont(name: "Pretendard-Regular", size: 12) ?? UIFont.systemFont(ofSize: 12)
         self.myLineChart.xAxis.yOffset = 8
         

--- a/AESPArd_FE/View/ResultTableView/EditPracticeView.swift
+++ b/AESPArd_FE/View/ResultTableView/EditPracticeView.swift
@@ -54,7 +54,7 @@ class EditPracticeView: UIView {
     let practiceDeleteButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("발표 파일 삭제하기", for: .normal)
+        button.setTitle("연습 파일 삭제하기", for: .normal)
         button.setTitleColor(UIColor(red: 0, green: 0, blue: 0, alpha: 1), for: .normal)
         button.backgroundColor = .white
         button.contentHorizontalAlignment = .left


### PR DESCRIPTION
1. list 페이지
- 해당 발표 하나 삭제 api
- 연습 선택 삭제 api
- 발표 이름 수정 api
2. report 페이지
- 해당 연습 하나 삭제 api
- 연습 이름 수정 api